### PR TITLE
ci: Fix pipeline to use docker compose v2

### DIFF
--- a/.jenkins/deploy/Jenkinsfile
+++ b/.jenkins/deploy/Jenkinsfile
@@ -16,12 +16,12 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh('docker-compose run env npm run docs:build')
+                sh('docker compose run env npm run docs:build')
             }
         }
         stage('Deploy') {
             steps {
-                sh('docker-compose run env npm run docs:deploy')
+                sh('docker compose run env npm run docs:deploy')
             }
         }
         stage('Push') {
@@ -35,7 +35,7 @@ pipeline {
                     --username $REGISTRY_CREDS_USR \
                     --password $REGISTRY_CREDS_PSW \
                     $REGISTRY_DOMAIN')
-                sh('docker-compose push')
+                sh('docker compose push')
                 sh('docker logout $REGISTRY_DOMAIN')
             }
         }


### PR DESCRIPTION
Update jenkinsfile to use docker compose v2

Updates the jenkinsfile to use docker compose v2 instead of old docker-compose v1.

### Changed

-   Jenkinsfile: changed `docker-compose` to `docker compose`

-   [ x ] I have read the [code of conduct](../CODE_OF_CONDUCT.md) and accept it.
-   [ x ] I have read the [contributing guidelines](../CONTRIBUTING.md) and accept them.
-   [ x ] I have read the [writing guidelines](../GUIDELINES.md) and accept them.
-   [ x ] I accept that my contribution will be licensed under a [CC BY-SA 4.0 License](../LICENSE).
