### PR TITLE
chore(deps): Bump versions of NPM dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,13 +78,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-            "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.2"
+                "@babel/types": "^7.28.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -94,9 +94,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -360,23 +360,23 @@
             "license": "MIT"
         },
         "node_modules/@cspell/dict-en_us": {
-            "version": "4.4.18",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.18.tgz",
-            "integrity": "sha512-6Le961Q0AIfVp3nKuSJJD/9NfnTYA1N/MLAaeWKCABEvhzhopeyGrykwejd0SA4m64WBUNEfSlsgselYWoDSjQ==",
+            "version": "4.4.19",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.19.tgz",
+            "integrity": "sha512-JYYgzhGqSGuIMNY1cTlmq3zrNpehrExMHqLmLnSM2jEGFeHydlL+KLBwBYxMy4e73w+p1+o/rmAiGsMj9g3MCw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@cspell/dict-en-common-misspellings": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.5.tgz",
-            "integrity": "sha512-hlRDSjul7wGTDXeLBADoyTGIZjWWZn6/SP+pt0lG3PRtqF0MWH/QEDgUkS+Yev7ZhHCHVLvwBZtDxOd1uw06Tw==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.6.tgz",
+            "integrity": "sha512-xV9yryOqZizbSqxRS7kSVRrxVEyWHUqwdY56IuT7eAWGyTCJNmitXzXa4p+AnEbhL+AB2WLynGVSbNoUC3ceFA==",
             "dev": true,
             "license": "CC BY-SA 4.0"
         },
         "node_modules/@cspell/dict-en-gb-mit": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.8.tgz",
-            "integrity": "sha512-wrZDRl6TKd1wReepGDPuT1JNbnRjHLvtAVrozp0DUkFlcDgnrB+YSd/Ne4aKnkXl5qpyVQ2GG7a4Z7INKCX+fw==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.9.tgz",
+            "integrity": "sha512-1lSnphnHTOxnpNLpPLg1XXv8df3hs4oL0LJ6dkQ0IqNROl8Jzl6PD55BDTlKy4YOAA76dJlePB0wyrxB+VVKbg==",
             "dev": true,
             "license": "MIT"
         },
@@ -548,9 +548,9 @@
             "license": "MIT"
         },
         "node_modules/@cspell/dict-npm": {
-            "version": "5.2.15",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.15.tgz",
-            "integrity": "sha512-kb9oX/N5FUlJYoqc5G+tIP/0SolteFMz2VhOVKG2qiXUS/1AybVTjUEo4gZ4uEveUhLzUDcfpZbn40EoUVBVrg==",
+            "version": "5.2.17",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.17.tgz",
+            "integrity": "sha512-0yp7lBXtN3CtxBrpvTu/yAuPdOHR2ucKzPxdppc3VKO068waZNpKikn1NZCzBS3dIAFGVITzUPtuTXxt9cxnSg==",
             "dev": true,
             "license": "MIT"
         },
@@ -621,9 +621,9 @@
             "license": "MIT"
         },
         "node_modules/@cspell/dict-software-terms": {
-            "version": "5.1.7",
-            "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.7.tgz",
-            "integrity": "sha512-CfNFQCVx8R/D8RfFdFTwSjDvXcSXY0tO+VN2N6TEbNTL1GCmqyzhwm4YI+ZbO3MUmMAMjwu9jZyoLk5BaJkXcg==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.1.8.tgz",
+            "integrity": "sha512-iwCHLP11OmVHEX2MzE8EPxpPw7BelvldxWe5cJ3xXIDL8TjF2dBTs2noGcrqnZi15SLYIlO8897BIOa33WHHZA==",
             "dev": true,
             "license": "MIT"
         },
@@ -2652,9 +2652,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-            "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3294,9 +3294,9 @@
             }
         },
         "node_modules/chalk": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-            "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3307,9 +3307,9 @@
             }
         },
         "node_modules/chalk-template": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.0.tgz",
-            "integrity": "sha512-T2VJbcDuZQ0Tb2EWwSotMPJjgpy1/tGee1BTpUNsGZ/qgNjV2t7Mvu+d4600U564nbLesN1x2dPL+xii174Ekg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
+            "integrity": "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6145,16 +6145,26 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
-            "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.0.tgz",
+            "integrity": "sha512-gEf705MZLrDPkbbhi8PnoO4ZwYgKoNL+ISZ3AjZMht2r3N5tuTwncyDi6Fv2/qDnMmZxgs0yI8WDOyR8q3G+SQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "lru-cache": "^10.0.1"
+                "lru-cache": "^11.1.0"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/hosted-git-info/node_modules/lru-cache": {
+            "version": "11.2.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+            "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/html-url-attributes": {
@@ -12911,18 +12921,18 @@
             }
         },
         "node_modules/normalize-package-data": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
-            "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+            "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "hosted-git-info": "^8.0.0",
+                "hosted-git-info": "^9.0.0",
                 "semver": "^7.3.5",
                 "validate-npm-package-license": "^3.0.4"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/normalize-path": {
@@ -20402,9 +20412,9 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -20663,14 +20673,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -22567,9 +22577,9 @@
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
Security fixes, see GitHub issue:
<https://github.com/debug-js/debug/issues/1005#issuecomment-3266868187>