### PR TITLE
Add Suite+ bundle installation notes to guides

### DIFF
--- a/docs/de/admin/suite-plus.md
+++ b/docs/de/admin/suite-plus.md
@@ -6,6 +6,10 @@ So müssen Sie dieselben Einträge nicht an zwei Stellen pflegen.
 
 Diese Seite beschreibt die i-doit-up-Seite der Bridge: die *Suite+*-Einstellungsoberfläche, den Sprung zum Suite+-Objekt, das Single-Sign-On-Verhalten und den Datenfluss in beide Richtungen.
 
+!!! info
+    Diese Seite beschreibt die i-doit-up-Seite einer **bereits eingerichteten** Bridge.
+    Die initiale Installation von i-doit up als Teil des Suite+ Bundles erfolgt über die [Suite+-Anleitung zur i-doit-up-Einrichtung](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung).
+
 ## Was die Bridge leistet
 
 Die Bridge ist eine von i-doit GmbH betriebene Middleware, die einen i-doit-up-Mandanten mit einem Suite+-Workspace verbindet.
@@ -113,4 +117,5 @@ Zum Aktivieren der Bridge wenden Sie sich an Ihren i-doit GmbH-Ansprechpartner; 
 - [Benachrichtigungen](../user/basics/notifications.md): hier erscheinen Bridge-Toasts.
 - [Rechte und Berechtigungen](rights-and-permissions.md): regeln, wer die Suite+-Einstellungsseite öffnen darf.
 - [Objektdetailseite](../user/basics/object-details.md): Host des Widgets *In Suite+ öffnen*.
+- [Suite+-Anleitung zur i-doit-up-Einrichtung](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung): Installation von i-doit up als Teil des Suite+ Bundles.
 - [Suite+-Dokumentation zur i-doit up Bridge](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-bridge): die Suite+-Seite derselben Integration.

--- a/docs/de/installation/index.md
+++ b/docs/de/installation/index.md
@@ -11,6 +11,10 @@ Sie deckt den Weg vom Download über die Konfiguration bis zum ersten Start ab u
 
 Getestet mit Version 3.1.0 auf Debian 13 (amd64).
 
+!!! info
+    Diese Seite beschreibt die **Self-Hosted-Installation** per Docker Compose.
+    Wenn Sie das **Suite+ Bundle** (Suite+ inklusive i-doit up) einrichten, folgen Sie stattdessen der [Suite+-Anleitung zur i-doit-up-Einrichtung](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung).
+
 ## Voraussetzungen
 
 | Anforderung | Hinweis |
@@ -206,3 +210,4 @@ docker compose down --rmi all --volumes
 - [Abonnement, Abrechnung und Upgrade](../admin/subscription.md)
 - [Benutzerverwaltung](../admin/user-management.md)
 - [Rechte und Berechtigungen](../admin/rights-and-permissions.md)
+- [Suite+-Anleitung zur i-doit-up-Einrichtung](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung): Installation als Teil des Suite+ Bundles

--- a/docs/en/admin/suite-plus.md
+++ b/docs/en/admin/suite-plus.md
@@ -5,6 +5,10 @@ Once the bridge is connected for your tenant, objects you create in i-doit up ap
 
 This page describes the i-doit up side of the bridge, the *Suite+* settings surface, the per-object jump action, the single-sign-on behavior, and how data flows in both directions.
 
+!!! info
+    This page describes the i-doit up side of a bridge that is **already set up**.
+    The initial installation of i-doit up as part of the Suite+ bundle runs through the [Suite+ guide to setting up i-doit up](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung).
+
 ## What the bridge does
 
 The bridge is a i-doit GmbH-operated middleware that connects one i-doit up tenant to one Suite+ workspace.
@@ -112,4 +116,5 @@ To activate the bridge, contact your i-doit GmbH representative; the underlying 
 - [Notifications](../user/basics/notifications.md), the toast catalog where bridge events surface.
 - [Rights and permissions](rights-and-permissions.md), controls who can reach the Suite+ settings page.
 - [Object details page](../user/basics/object-details.md), host of the *Open in Suite+* widget.
+- [Suite+ guide to setting up i-doit up](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung): installation of i-doit up as part of the Suite+ bundle.
 - [Suite+ documentation for the i-doit up bridge](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-bridge), the Suite+ side of the same integration.

--- a/docs/en/installation/index.md
+++ b/docs/en/installation/index.md
@@ -25,6 +25,10 @@ Tested with version 3.1.0 on Debian 13 (amd64).
 
 A comfortable setup needs at least **4 CPU cores** and **6 GB RAM**.
 
+!!! info
+    This page describes the **self-hosted installation** via Docker Compose.
+    If you are setting up the **Suite+ bundle** (Suite+ including i-doit up), follow the [Suite+ guide to setting up i-doit up](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung) instead.
+
 ## Step 1: Find the current version
 
 Fetch the current release identifier:
@@ -206,3 +210,4 @@ docker compose down --rmi all --volumes
 - [Subscription, billing, and upgrade](../admin/subscription.md)
 - [User management](../admin/user-management.md)
 - [Rights and permissions](../admin/rights-and-permissions.md)
+- [Suite+ guide to setting up i-doit up](https://suiteplus-wikijs.i-doit.com/de/integration/i-doit-up-einrichtung): installation as part of the Suite+ bundle.


### PR DESCRIPTION
Enhance installation guides by adding notes for setting up the Suite+ bundle, directing users to the appropriate resources.

### Added

-   Installation notes for the Suite+ bundle in both English and German.
-   Links to the Suite+ guide for setting up i-doit up.

### Changed

-   Updated installation guides to include Suite+ bundle information.

### Fixed

-   No fixes applied.

### Removed

-   No removals made.
